### PR TITLE
Implement concept of "Tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ from llm.openai import OpenAILanguageModel
 from playwright_helper import PlaywrightHelper
 
 # Support for custom tooling for RAG context aggregation
-from sources.datasource import Datasource
-from sources.google_stock_datasource import GoogleStockDatasource
+from sources.tool import Tool
+from sources.google_stock_tool import GoogleStockTool
 
 # Feed in user input
 company_name = "billionaire car guy who owns twitter"
@@ -39,15 +39,15 @@ async with PlaywrightHelper(launch_options={"headless": True}) as playwright_hel
     googleai_llm = GoogleLanguageModel()
 
     stock_lookup_parameters = {"company_name_query": company_name}
-    googleStockDatasource: Datasource = GoogleStockDatasource(
+    googleStockTool: Tool = GoogleStockTool(
         source_params=stock_lookup_parameters,
         playwright=playwright_helper,
         llm=googleai_llm,
     )
 
     print(f"Pulling stock information for: {company_name}, please wait...")
-    result = await googleStockDatasource.pull_content()
-    googleStockDatasource.pretty_print_stock_data(result)
+    result = await googleStockTool.pull_content()
+    googleStockTool.pretty_print_stock_data(result)
 ```
 
 _Output_

--- a/examples/google_stockprice_tool.py
+++ b/examples/google_stockprice_tool.py
@@ -9,8 +9,8 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "s
 from llm.google import GoogleLanguageModel
 from llm.openai import OpenAILanguageModel
 from playwright_helper import PlaywrightHelper
-from sources.datasource import Datasource
-from sources.google_stock_datasource import GoogleStockDatasource
+from tools.google_stock_tool import GoogleStockTool
+from tools.tool import Tool
 
 load_dotenv()
 
@@ -22,15 +22,15 @@ async def main() -> None:
         # openai_llm = OpenAILanguageModel()
         googleai_llm = GoogleLanguageModel()
 
-        googleStockDatasource: Datasource = GoogleStockDatasource(
+        googleStockTool: Tool = GoogleStockTool(
             source_params={"company_name_query": company_name},
             playwright=playwright_helper,
             llm=googleai_llm,
         )
 
         print(f"Pulling stock information for: {company_name}, please wait...")
-        result = await googleStockDatasource.pull_content()
-        googleStockDatasource.pretty_print_stock_data(result)
+        result = await googleStockTool.pull_content()
+        googleStockTool.pretty_print_stock_data(result)
 
 
 if __name__ == "__main__":

--- a/scripts/stockprice.sh
+++ b/scripts/stockprice.sh
@@ -1,1 +1,1 @@
-python examples/google_stockprice_datasource.py "$1"
+python examples/google_stockprice_tool.py "$1"

--- a/src/tools/tool.py
+++ b/src/tools/tool.py
@@ -4,14 +4,15 @@ from llm.llm import LanguageModel
 from playwright_helper import PlaywrightHelper
 
 
-class DatasourceOptions(TypedDict, total=False):
+class ToolOptions(TypedDict, total=False):
     llm: LanguageModel
     source_params: Dict[str, Any]
     playwright: PlaywrightHelper
 
 
-class Datasource(Protocol):
-    def __init__(self, **opts: DatasourceOptions): ...
+class Tool(Protocol):
+
+    def __init__(self, **opts: ToolOptions): ...
 
     async def pull_content(
         self,


### PR DESCRIPTION
Adds concept of tools that can be used when working with LLMs. This already existed, but I'm wanting to cement the conventions moving forward.

Ultimately DirtyRAG will have the ability to reason about tasks conditionally by traversing through an acyclic graph. Each node in the graph will encapsulate some notion of a task which is managed via a task agent. I still want to think about the design for determining paths to take (router node concepts for picking next node), but that will come later.

Tools will be encapsulated within the agent interface to widen the flexibility an agent has when reasoning about its desired output. 

For example, you might have a `SearchAgent` that is used for hybrid search when performing semantic analysis. Tools on that agent might include scraping tools for Google, a Bing search API as well as a embedding tool used against a custom datastore of vector embeddings for semantic search.

The agent itself will have parameters to define iteration and fine-tuning logic on the final output, but so will the tools. The goal is that tool output will be used as additional context that gets paired with the original input to optimize the LLM output. This data will either be fed directly into a router node for ranking the next best decision or will be fed as input into the next node directly.

